### PR TITLE
[WIP] Implement "Maybe[T]" type

### DIFF
--- a/example/test_maybe.py
+++ b/example/test_maybe.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from graphotype.maybe import Maybe, maybe, Nothing
+
+@dataclass
+class Bar:
+    value: int = 0
+
+@dataclass
+class Foo:
+    bar: Optional[Bar]
+
+@dataclass
+class Root:
+    foo: Optional[Foo]
+
+
+example1 = Root(Foo(Bar(1)))
+example2 = Root(Foo(None))
+example3 = Root(None)
+
+m1: Maybe[Root] = maybe(None)
+
+#m1.cows
+#reveal_type(m1.foo)
+reveal_type(m1.delicious())
+#reveal_type(m1.foo_)
+#reveal_type(m1.foo_.bar)
+#reveal_type(m1.foo_.bar_.value)
+#reveal_type(m1.foo_.bar_.value_)
+
+
+
+#assert maybe(None).cows is Nothing
+#assert maybe(0) is not Nothing
+#assert maybe(example1) is not Nothing

--- a/graphotype/maybe.py
+++ b/graphotype/maybe.py
@@ -1,0 +1,67 @@
+import abc
+from dataclasses import dataclass
+from typing import Generic, TypeVar, Any, Callable, Optional
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+CHAINING_SUFFIX = "_"
+
+
+#class Maybe(Generic[T]):
+class Maybe:
+    def __getattr__(self, item: str) -> Any:
+        if item.endswith(CHAINING_SUFFIX):
+            # M a -> name -> M b
+            result = self._bind(lambda unwrapped: getattr(unwrapped, item[:-1]))
+            return result
+        else:
+            # M a -> name -> Optional[b]
+            result = self._chain(lambda unwrapped: getattr(unwrapped, item))
+            return result
+
+
+    @abc.abstractmethod
+    def _chain(self, f: Callable[[T], R]) -> Optional[R]:
+        """If self is Nothing, return None. Otherwise return f(*self)."""
+
+    def _bind(self, f: Callable[[T], R]) -> Any:
+        """If self is Nothing, return Nothing. Else return Some(f(*self))."""
+        result = self._chain(lambda unwrapped: maybe(f(unwrapped))) or Nothing
+        return result
+
+
+class _Nothing(Maybe):
+#class _Nothing(Maybe[T]):
+    """Implementation of the only Nothing value"""
+    def _chain(self, f: Callable[[T], R]) -> Optional[R]:
+        return None
+
+    def __repr__(self):
+        return "Nothing"
+
+
+Nothing = _Nothing()
+
+
+@dataclass
+class Some(Maybe):
+#class Some(Maybe[T]):
+    _value: T
+
+    def __post_init__(self) -> None:
+        assert self._value is not None and self._value is not Nothing, "Some() constructor called with None. Use maybe() instead."
+
+    def _chain(self, f: Callable[[T], R]) -> Optional[R]:
+        return f(self._value)
+
+
+def maybe(value: Optional[T]) -> Any:
+    """Wrap an optional T into a Maybe[T], giving you Nothing or Some(value).
+
+    'value' must not already be a Maybe.
+    """
+    assert not isinstance(value, Maybe), "maybe() called on something which is already a Maybe"
+    if value is None:
+        return Nothing
+    return Some(value)

--- a/graphotype/maybe.pyi
+++ b/graphotype/maybe.pyi
@@ -1,0 +1,16 @@
+from typing import Generic, TypeVar, Any, Callable, Optional
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+class Maybe(Generic[T]):
+    cows: int
+    def __getattr__(self, item): ...
+
+    @property
+    def delicious(self) -> int:
+        pass
+
+Nothing: Maybe[Any]
+
+def maybe(value: Optional[T]) -> Maybe[T]: ...

--- a/graphotype/maybe_plugin_getattr_hook.py
+++ b/graphotype/maybe_plugin_getattr_hook.py
@@ -1,0 +1,69 @@
+from typing import Optional, Callable, Union, List
+
+from mypy.nodes import TypeInfo, SymbolTable, ClassDef, Block, MemberExpr, NameExpr
+from mypy.plugin import AnalyzeTypeContext, Plugin, AttributeContext
+from mypy.types import Type, AnyType, TypeOfAny, JsonDict, deserialize_type, Instance, TypeVarType, UnionType, NoneTyp
+
+
+class MaybePlugin(Plugin):
+    def get_attribute_hook(self, fullname: str
+                           ) -> Optional[Callable[[AttributeContext], Type]]:
+        if fullname.startswith('graphotype.maybe.Maybe'):
+            print(f"Getattr({fullname})")
+            return maybe_getattr_hook
+
+def maybe_getattr_hook(ctx: AttributeContext) -> Type:
+    """Called when we recognize a Maybe attribute access"""
+
+    if isinstance(ctx.type, Instance):
+        # a Maybe instance! let's see if we can resolve the argument.
+        arg = ctx.type.args[0]
+        if isinstance(arg, Instance) and isinstance(ctx.context, MemberExpr):
+            # Ok, we can check this Maybe[Thingy].attrib attribute access by returning the
+            # Thingy.attrib
+            return get_type_of_maybe_attrib_access(ctx, arg, ctx.context.name)
+
+    # Either this is not an instance of Maybe[Thingy], or Thingy is something we don't know
+    # (yet?) how to introspect. Either way, fallback to the default attribute handler.
+    return ctx.default_attr_type
+
+def get_type_of_maybe_attrib_access(ctx: AttributeContext, arg: Instance, name: str) -> Type:
+    use_maybe_handler = False
+    if name.endswith("_"):
+        # Use the Maybe handler
+        orig_type_stnode = arg.type.get(name[:-1])
+        use_maybe_handler = True
+    else:
+        orig_type_stnode = arg.type.get(name)
+
+    if orig_type_stnode:
+        # The name exists in the original context
+        orig_type = make_required(orig_type_stnode.type)
+        print(f"Use {'maybe' if use_maybe_handler else 'opt'} handler: {orig_type}")
+
+        if use_maybe_handler:
+            # Wrap orig_type in Maybe[]
+            return ctx.api.named_generic_type('graphotype.maybe.Maybe', [orig_type])
+        else:
+            # Wrap orig_type in Optional[]
+            return make_optional(orig_type)
+
+    else:
+        ctx.api.fail(f"No attribute named {arg}.{name} (via Maybe[{arg}])", ctx.context)
+
+    return ctx.default_attr_type
+
+def plugin(version: str):
+    # ignore version argument if the plugin works with all mypy versions.
+    print("Plugin init")
+    return MaybePlugin
+
+# These 2 helpers from https://github.com/python/mypy/issues/5409
+def make_required(typ: Type):
+    if not isinstance(typ, UnionType):
+        return typ
+    items = [item for item in typ.items if not isinstance(item, NoneTyp)]
+    return UnionType.make_union(items)
+
+def make_optional(typ: Type):
+    return UnionType.make_simplified_union([typ, NoneTyp()])

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,4 @@
 [mypy]
 
-plugins = graphotype.mypy_plugin:plugin
+#plugins = graphotype.mypy_plugin:plugin
+plugins = graphotype.maybe_plugin_getattr_hook:plugin

--- a/tests/test_maybe.py
+++ b/tests/test_maybe.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from graphotype.maybe import maybe, Nothing
+
+@dataclass
+class Bar:
+    value: int = 0
+
+@dataclass
+class Foo:
+    bar: Optional[Bar]
+
+@dataclass
+class Root:
+    foo: Optional[Foo]
+
+
+example1 = Root(Foo(Bar(1)))
+example2 = Root(Foo(None))
+example3 = Root(None)
+
+
+def test_maybe_fn():
+    assert maybe(None) is Nothing
+    assert maybe(0) is not Nothing
+    assert maybe(example1) is not Nothing
+
+
+def test_chaining_to_optional():
+    assert maybe(example1).foo is not None
+    assert maybe(example2).foo is not None
+    assert maybe(example3).foo is None
+
+
+def test_chaining_to_maybe():
+    assert maybe(example1).foo_ is not Nothing
+    assert maybe(example2).foo_ is not Nothing
+    assert maybe(example3).foo_ is Nothing
+
+
+def test_multi_step_chaining():
+    assert maybe(example1).foo_.bar is not None
+    assert maybe(example2).foo_.bar is None
+    assert maybe(example3).foo_.bar is None
+
+    assert maybe(example1).foo_.bar_.value == 1
+    assert maybe(example2).foo_.bar_.value is None
+    assert maybe(example3).foo_.bar_.value is None
+
+


### PR DESCRIPTION
The Maybe type is not quite ready yet, but I wanted to create this issue bc it's not far from usable.

- [ ] Consider whether 'graphotype.maybe' is the right package for the Maybe type, and/or whether it should even be called Maybe as opposed to, e.g., `ChainedOptional`
- [ ] Get the 'getattribute hook' changes to mypy merged (https://github.com/python/mypy/pull/6371)
- [ ] It is probably a good idea to autotest that the mypy plugin works as-expected. Right now I just run mypy against the example/test_maybe.py file and look at the output.
- [ ] I should not comment out the graphotype plugin from the mypy.ini.
- [ ] Lots of small cleanups, remove print statements, etc.